### PR TITLE
BDRK-687 Changed reference to renamed bedrock client 

### DIFF
--- a/bedrock.hcl
+++ b/bedrock.hcl
@@ -93,7 +93,7 @@ batch_score {
 serve {
     image = "python:3.7"
     install = [
-        "pip install ply bedrock-cli numpy lightgbm grpcio-tools grpcio protobuf",
+        "pip install ply bdrk numpy lightgbm grpcio-tools grpcio protobuf",
         "python3 -m grpc_tools.protoc -I protos --python_out=. --grpc_python_out=. protos/serve.proto"
     ]
     script = ["python3 serve.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ google-cloud==0.34.0
 google-cloud-bigquery[pandas,pyarrow]==1.11.3
 gcsfs==0.2.2
 pyarrow==0.13.0
-bedrock-cli==1.0.0
+bdrk==0.0.1
 pyspark==2.4.3


### PR DESCRIPTION
**Problem:**
[BDRK-687]

**Description:**

The bedrock python client has been renamed to `bdrk`
Cleaning up the references

[BDRK-687]: https://basis-ai.atlassian.net/browse/BDRK-687