### PR TITLE
Change the implementaion to use the bedrock client library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip==19.2.3
-bdrk==0.1.2
+bdrk==0.1.4
 numpy==1.17.0
 pandas==0.25.0
 lightgbm==2.2.3

--- a/utils/artefact.py
+++ b/utils/artefact.py
@@ -7,13 +7,12 @@ from bdrk.v1 import ApiClient, Configuration, ModelApi, PipelineApi, ServeApi
 
 configuration = Configuration()
 
+# This is your personal access token https://docs.basis-ai.com/getting-started/rest-apis/personal-api-token
 configuration.api_key["X-Bedrock-Access-Token"] = os.environ["BEDROCK_ACCESS_TOKEN"]
-configuration.host = os.environ['BEDROCK_API_DOMAIN']
+configuration.host = os.environ.get("BEDROCK_API_DOMAIN", "https://api.bdrk.ai")
 
 api_client = ApiClient(configuration)
 pipeline_api = PipelineApi(api_client)
-serve_api = ServeApi(api_client)
-model_api = ModelApi(api_client)
 
 
 def download_artefact_by_run_id(
@@ -84,9 +83,11 @@ def download_artefact_from_latest_run(
     last_run = _get_latest_run(pipeline_id)
 
     # Calls Bedrock API again to download artefact from the latest run
-    filename = download_artefact_by_run_id(pipeline_id=pipeline_id,
-                                           pipeline_run_id=last_run.entity_id,
-                                           output_filepath=output_filepath)
+    filename = download_artefact_by_run_id(
+        pipeline_id=pipeline_id,
+        pipeline_run_id=last_run.entity_id,
+        output_filepath=output_filepath
+    )
 
     print(f"Downloaded artefact: {filename}")
     return filename
@@ -122,10 +123,12 @@ def download_and_unzip_latest_artefact(output_directory: Optional[str] = None) -
     last_run = _get_latest_run(pipeline_id)
 
     # Extract the downloaded artefacts
-    download_and_unzip_artefact(api_client=api_client,
-                                model_id=pipeline.model_id,
-                                model_artefact_id=last_run.artefact_id,
-                                output_dir=output_directory or f"/tmp/{pipeline_id}")
+    download_and_unzip_artefact(
+        api_client=api_client,
+        model_id=pipeline.model_id,
+        model_artefact_id=last_run.artefact_id,
+        output_dir=output_directory or f"/tmp/{pipeline_id}"
+    )
 
     # List the contents for manual verification
     print(glob.glob(f"{output_directory}/*"))


### PR DESCRIPTION
[[BDRK-1093]](https://basis-ai.atlassian.net/browse/BDRK-1093) - Update download_artefact code snippet to use client library

Change the implementation of download_artefact using client library

**Tests:**
* Tested download_and_unzip_latest_artefact api for download_artefacts.
* The other api download_artefact_by_run_id() has following issue:

**Note:** pipeline_api.get_training_pipeline_run api currently returning None for artefact_id. 
Need to fix it. Creating PR for getting overall comments.

[BDRK-1093]: https://basis-ai.atlassian.net/browse/BDRK-1093