### PR TITLE
Bump bdrk to 0.3.0

### DIFF
--- a/requirements-serve.txt
+++ b/requirements-serve.txt
@@ -1,4 +1,4 @@
-bdrk[model-monitoring]==0.2.1
+bdrk[model-monitoring]==0.3.0rc1
 numpy==1.18.4
 lightgbm==2.3.1
 flask==1.1.2

--- a/requirements-serve.txt
+++ b/requirements-serve.txt
@@ -1,4 +1,4 @@
-bdrk[model-monitoring]==0.3.0rc1
+bdrk[model-monitoring]==0.3.0
 numpy==1.18.4
 lightgbm==2.3.1
 flask==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bdrk[model-monitoring]==0.3.0rc1
+bdrk[model-monitoring]==0.3.0
 numpy==1.18.4
 pandas==1.0.3
 lightgbm==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bdrk[model-monitoring]==0.2.1
+bdrk[model-monitoring]==0.3.0rc1
 numpy==1.18.4
 pandas==1.0.3
 lightgbm==2.3.1


### PR DESCRIPTION
New version exports feature distribution metadata which is required for transitioning to victoria metrics.