### PR TITLE
[BDRK-3302] Simplify spark configuration using default params

### DIFF
--- a/bedrock.hcl
+++ b/bedrock.hcl
@@ -28,7 +28,10 @@ train {
 
   step "generate_features" {
     image = "quay.io/basisai/workload-standard:v0.3.1"
-    install = []
+    install = [
+      "pip3 install --upgrade pip",
+      "pip3 install -r requirements.txt",
+    ]
     script = [
       {
         spark-submit = {
@@ -120,7 +123,10 @@ batch_score {
 
   step "generate_features" {
     image = "quay.io/basisai/workload-standard:v0.3.1"
-    install = []
+    install = [
+      "pip3 install --upgrade pip",
+      "pip3 install -r requirements.txt",
+    ]
     script = [
       {
         spark-submit = {

--- a/bedrock.hcl
+++ b/bedrock.hcl
@@ -2,6 +2,7 @@ version = "1.0"
 
 train {
   step "preprocess" {
+    # Same as spark.kubernetes.container.image
     image = "quay.io/basisai/workload-standard:v0.3.1"
     install = [
       "pip3 install --upgrade pip",
@@ -12,23 +13,18 @@ train {
         spark-submit = {
           script = "preprocess.py"
           conf = {
-            "spark.kubernetes.container.image"       = "quay.io/basisai/workload-standard:v0.3.1"
-            "spark.kubernetes.pyspark.pythonVersion" = "3"
-            "spark.driver.memory"                    = "4g"
-            "spark.driver.cores"                     = "2"
             "spark.executor.instances"               = "2"
             "spark.executor.memory"                  = "4g"
             "spark.executor.cores"                   = "2"
-            "spark.memory.fraction"                  = "0.5"
             "spark.sql.parquet.compression.codec"    = "gzip"
-            "spark.hadoop.fs.s3a.impl"               = "org.apache.hadoop.fs.s3a.S3AFileSystem"
-            "spark.hadoop.fs.s3a.endpoint"           = "s3.ap-southeast-1.amazonaws.com"
           }
         }
       }
     ]
     resources {
+      # Same as spark.driver.cores
       cpu    = "0.5"
+      # Same as spark.driver.memory
       memory = "1G"
     }
   }
@@ -44,18 +40,10 @@ train {
         spark-submit = {
           script = "generate_features.py"
           conf = {
-            "spark.kubernetes.container.image"       = "quay.io/basisai/workload-standard:v0.3.1"
-            "spark.kubernetes.pyspark.pythonVersion" = "3"
-            "spark.driver.memory"                    = "4g"
-            "spark.driver.cores"                     = "2"
             "spark.executor.instances"               = "2"
             "spark.executor.memory"                  = "4g"
             "spark.executor.cores"                   = "2"
-            "spark.memory.fraction"                  = "0.5"
             "spark.sql.parquet.compression.codec"    = "gzip"
-            "spark.hadoop.fs.s3a.impl"               = "org.apache.hadoop.fs.s3a.S3AFileSystem"
-            "spark.hadoop.fs.s3a.endpoint"           = "s3.ap-southeast-1.amazonaws.com"
-
           }
         }
       }
@@ -126,17 +114,10 @@ batch_score {
         spark-submit = {
           script = "preprocess.py"
           conf = {
-            "spark.kubernetes.container.image"       = "quay.io/basisai/workload-standard:v0.3.1"
-            "spark.kubernetes.pyspark.pythonVersion" = "3"
-            "spark.driver.memory"                    = "4g"
-            "spark.driver.cores"                     = "2"
             "spark.executor.instances"               = "2"
             "spark.executor.memory"                  = "4g"
             "spark.executor.cores"                   = "2"
-            "spark.memory.fraction"                  = "0.5"
             "spark.sql.parquet.compression.codec"    = "gzip"
-            "spark.hadoop.fs.s3a.impl"               = "org.apache.hadoop.fs.s3a.S3AFileSystem"
-            "spark.hadoop.fs.s3a.endpoint"           = "s3.ap-southeast-1.amazonaws.com"
           }
       } }
     ]
@@ -157,17 +138,10 @@ batch_score {
         spark-submit = {
           script = "generate_features.py"
           conf = {
-            "spark.kubernetes.container.image"       = "quay.io/basisai/workload-standard:v0.3.1"
-            "spark.kubernetes.pyspark.pythonVersion" = "3"
-            "spark.driver.memory"                    = "4g"
-            "spark.driver.cores"                     = "2"
             "spark.executor.instances"               = "2"
             "spark.executor.memory"                  = "4g"
             "spark.executor.cores"                   = "2"
-            "spark.memory.fraction"                  = "0.5"
             "spark.sql.parquet.compression.codec"    = "gzip"
-            "spark.hadoop.fs.s3a.impl"               = "org.apache.hadoop.fs.s3a.S3AFileSystem"
-            "spark.hadoop.fs.s3a.endpoint"           = "s3.ap-southeast-1.amazonaws.com"
           }
       } }
     ]

--- a/bedrock.hcl
+++ b/bedrock.hcl
@@ -4,10 +4,7 @@ train {
   step "preprocess" {
     # Same as spark.kubernetes.container.image
     image = "quay.io/basisai/workload-standard:v0.3.1"
-    install = [
-      "pip3 install --upgrade pip",
-      "pip3 install -r requirements.txt",
-    ]
+    install = []
     script = [
       {
         spark-submit = {
@@ -31,10 +28,7 @@ train {
 
   step "generate_features" {
     image = "quay.io/basisai/workload-standard:v0.3.1"
-    install = [
-      "pip3 install --upgrade pip",
-      "pip3 install -r requirements.txt",
-    ]
+    install = []
     script = [
       {
         spark-submit = {
@@ -56,7 +50,7 @@ train {
   }
 
   step "train" {
-    image = "quay.io/basisai/workload-standard:v0.3.1"
+    image = "python:3.7"
     install = [
       "pip3 install --upgrade pip",
       "pip3 install -r requirements.txt",
@@ -105,10 +99,7 @@ serve {
 batch_score {
   step "preprocess" {
     image = "quay.io/basisai/workload-standard:v0.3.1"
-    install = [
-      "pip3 install --upgrade pip",
-      "pip3 install -r requirements.txt",
-    ]
+    install = []
     script = [
       {
         spark-submit = {
@@ -129,10 +120,7 @@ batch_score {
 
   step "generate_features" {
     image = "quay.io/basisai/workload-standard:v0.3.1"
-    install = [
-      "pip3 install --upgrade pip",
-      "pip3 install -r requirements.txt",
-    ]
+    install = []
     script = [
       {
         spark-submit = {
@@ -153,7 +141,7 @@ batch_score {
   }
 
   step "batch_score" {
-    image = "quay.io/basisai/workload-standard:v0.3.1"
+    image = "python:3.7"
     install = [
       "pip3 install --upgrade pip",
       "pip3 install -r requirements.txt",

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow
-bdrk[analyzer,model-monitoring]==0.9.0
+bdrk[analyzer,model-monitoring]>=0.9,<0.10
 seaborn
 lightgbm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
 safety==1.9.0
+# Provided in workload-standard image
+pyspark==3.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
 safety==1.9.0
-# Provided in workload-standard image
+# We use the same pyspark version for development as that provided in workload docker image,
+# ie. quay.io/basisai/workload-standard:v0.3.1. It's not recommended to install a different
+# version in bedrock.hcl because it must be kept in sync with spark's binary release.
+# https://spark.apache.org/downloads.html
 pyspark==3.1.2

--- a/requirements-serve.txt
+++ b/requirements-serve.txt
@@ -1,4 +1,4 @@
-bdrk[model-monitoring]>=0.9.0
+bdrk[model-monitoring]>=0.9,<0.10
 lightgbm==3.2.1
 flask==2.0.1
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ numpy==1.21.0
 pandas==1.3.0
 lightgbm==3.2.1
 scikit-learn==0.24.2
-pyspark==3.1.2
 fastparquet==0.6.3
 s3fs==2021.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bdrk[analyzer,model-monitoring]>=0.9.0
+bdrk[analyzer,model-monitoring]>=0.9,<0.10
 numpy==1.21.0
 pandas==1.3.0
 lightgbm==3.2.1


### PR DESCRIPTION
After upgrading to spark 3.1, users only need to provide executor configs as part of `spark-submit` stanza.

Tested on prod:
- Train: https://bedrock.basis-ai.com/project/view/qiao/training/pipeline/view/churn-fork/run/3
- Score: https://bedrock.basis-ai.com/project/view/qiao/deployment/batch-scoring/view/churn-aws/run/2